### PR TITLE
Accelerate with copilot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
+pytest
+httpx
 uvicorn

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball training and matches",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["alex@mergington.edu"]
+    },
+    "Tennis Club": {
+        "description": "Tennis lessons and friendly tournaments",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:00 PM",
+        "max_participants": 10,
+        "participants": ["sarah@mergington.edu", "james@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Painting, drawing, and sculpture techniques",
+        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["maya@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Acting, theatre production, and performance",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": ["lucas@mergington.edu", "isabella@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Explore scientific experiments and research projects",
+        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 22,
+        "participants": ["noah@mergington.edu", "ava@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop argumentation and public speaking skills",
+        "schedule": "Fridays, 3:30 PM - 4:30 PM",
+        "max_participants": 16,
+        "participants": ["benjamin@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import threading
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,8 +20,9 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
+# Persistent global activity database with thread safety
+_activities_lock = threading.Lock()
+_activities_data = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -77,31 +79,42 @@ activities = {
     }
 }
 
+def get_activities_data():
+    """Get a copy of activities data"""
+    with _activities_lock:
+        return dict(_activities_data)
+
+def get_activity(activity_name):
+    """Get a specific activity"""
+    with _activities_lock:
+        return _activities_data.get(activity_name)
 
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
 
-
 @app.get("/activities")
 def get_activities():
-    return activities
-
+    return get_activities_data()
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    activity = get_activity(activity_name)
+    if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is not already signed up
     if email in activity["participants"]:
         raise HTTPException(status_code=400, detail="Student already signed up for this activity")
-
-    # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+@app.delete("/activities/{activity_name}/unregister")
+def unregister_participant(activity_name: str, email: str):
+    """Remove a participant from an activity"""
+    activity = get_activity(activity_name)
+    if not activity:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Participant not found")
+    activity["participants"].remove(email)
+    return {"message": f"Removed {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -19,12 +19,19 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participantsList = details.participants
+          .map((p) => `<li>${p}</li>`)
+          .join("");
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants">
+            <h5>Participants (${details.participants.length})</h5>
+            <ul>${participantsList || "<li><em>No participants yet</em></li>"}</ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -19,9 +19,9 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
-        const participantsList = details.participants
-          .map((p) => `<li>${p}</li>`)
-          .join("");
+          const participantsList = details.participants
+            .map((p) => `<li><span>${p}</span><span class="delete-icon" title="Remove" data-activity="${name}" data-email="${p}">&#128465;</span></li>`)
+            .join("");
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
@@ -69,6 +69,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        fetchActivities(); // Refresh activities list after signup
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -90,4 +91,26 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Initialize app
   fetchActivities();
+
+  // Delegate click event for delete icons
+  activitiesList.addEventListener("click", async (event) => {
+    if (event.target.classList.contains("delete-icon")) {
+      const activity = event.target.getAttribute("data-activity");
+      const email = event.target.getAttribute("data-email");
+      if (activity && email) {
+        try {
+          const response = await fetch(`/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`, {
+            method: "DELETE",
+          });
+          if (response.ok) {
+            fetchActivities(); // Refresh list
+          } else {
+            alert("Failed to remove participant.");
+          }
+        } catch (err) {
+          alert("Error removing participant.");
+        }
+      }
+    }
+  });
 });

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -88,18 +88,33 @@ section h3 {
 }
 
 .participants ul {
-  margin-left: 20px;
-  list-style-type: disc;
+  margin-left: 0;
+  list-style-type: none;
+  padding-left: 0;
 }
 
 .participants li {
   margin-bottom: 5px;
   color: #555;
   font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .participants li:hover {
   color: #0066cc;
+}
+
+.delete-icon {
+  cursor: pointer;
+  margin-left: 10px;
+  color: #c62828;
+  font-size: 16px;
+  transition: color 0.2s;
+}
+.delete-icon:hover {
+  color: #a31515;
 }
 
 .form-group {

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,34 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.participants h5 {
+  font-size: 14px;
+  color: #1a237e;
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+
+.participants ul {
+  margin-left: 20px;
+  list-style-type: disc;
+}
+
+.participants li {
+  margin-bottom: 5px;
+  color: #555;
+  font-size: 14px;
+}
+
+.participants li:hover {
+  color: #0066cc;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,55 @@
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app
+
+client = TestClient(app)
+
+def test_get_activities():
+    response = client.get("/activities")
+    assert response.status_code == 200
+    data = response.json()
+    assert "Chess Club" in data
+    assert "Programming Class" in data
+
+def test_signup_for_activity():
+    email = "newstudent@mergington.edu"
+    activity = "Chess Club"
+    # Ensure not already signed up
+    client.delete(f"/activities/{activity}/unregister?email={email}")
+    response = client.post(f"/activities/{activity}/signup?email={email}")
+    assert response.status_code == 200
+    assert f"Signed up {email} for {activity}" in response.json()["message"]
+    # Try signing up again (should fail)
+    response = client.post(f"/activities/{activity}/signup?email={email}")
+    assert response.status_code == 400
+
+def test_unregister_participant():
+    from tests.util_state import get_participants
+    email = "removeme@mergington.edu"
+    activity = "Programming Class"
+    # Ensure not already present
+    client.delete(f"/activities/{activity}/unregister?email={email}")
+    assert email not in get_participants(activity)
+    # Sign up first
+    signup_response = client.post(f"/activities/{activity}/signup?email={email}")
+    assert signup_response.status_code == 200
+    assert email in get_participants(activity)
+    response = client.delete(f"/activities/{activity}/unregister?email={email}")
+    assert response.status_code == 200
+    assert f"Removed {email} from {activity}" in response.json()["message"]
+    assert email not in get_participants(activity)
+    # Try removing again (should fail)
+    response = client.delete(f"/activities/{activity}/unregister?email={email}")
+    assert response.status_code == 404
+
+def test_signup_invalid_activity():
+    response = client.post("/activities/Nonexistent/signup?email=test@mergington.edu")
+    assert response.status_code == 404
+
+def test_unregister_invalid_activity():
+    response = client.delete("/activities/Nonexistent/unregister?email=test@mergington.edu")
+    assert response.status_code == 404
+
+def test_unregister_invalid_participant():
+    response = client.delete("/activities/Chess Club/unregister?email=notfound@mergington.edu")
+    assert response.status_code == 404

--- a/tests/util_state.py
+++ b/tests/util_state.py
@@ -1,0 +1,4 @@
+def get_participants(activity_name):
+    from src.app import get_activity
+    activity = get_activity(activity_name)
+    return activity["participants"] if activity else []


### PR DESCRIPTION
This pull request introduces several improvements and new features to the Mergington High School activities app, focusing on thread safety, participant management, UI enhancements, and comprehensive testing. The main changes are the migration to a thread-safe activities database, the addition of endpoints and UI for participant removal, and expanded automated tests to cover new and existing functionality.

**Backend improvements:**

* Migrated the activities database in `src/app.py` to a global, thread-safe structure using a `threading.Lock`, and provided helper functions for safe access (`get_activities_data`, `get_activity`). [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R13) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L22-R25)
* Added a new DELETE endpoint `/activities/{activity_name}/unregister` to allow removal of participants from activities, with proper error handling for invalid cases.

**Frontend enhancements:**

* Updated `src/static/app.js` to display a list of participants for each activity, with a delete icon next to each participant for removal. Clicking the icon triggers a DELETE request to the backend and refreshes the list. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R22-R34) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R94-R115)
* Improved the UI styles in `src/static/styles.css` for the participants list and delete icon, making participant management more user-friendly and visually clear.

**Testing:**

* Added new tests in `tests/test_app.py` to verify listing activities, signing up, unregistering participants, and error cases for invalid activities and participants. Also introduced a utility function in `tests/util_state.py` for accessing participant lists in tests. [[1]](diffhunk://#diff-a67cb1853203a6f1956991a9d9881d231c4d43557f5baffd45cc672a87e41cc6R1-R55) [[2]](diffhunk://#diff-17f5c466e628b570c8e51b125f7dfa1cb5a214d35c3b980d60c4c76c194b2b86R1-R4)